### PR TITLE
chore: refine SonarCloud exclusions for non-code directories

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,4 @@ sonar.projectKey=petry-projects_broodly
 sonar.organization=petry-projects
 sonar.projectName=broodly
 sonar.sources=.
-sonar.exclusions=_bmad-output/**,.claude/**
+sonar.exclusions=_bmad/**,_bmad-output/**,.claude/**


### PR DESCRIPTION
## Summary
- Add `_bmad/**` to `sonar.exclusions` (BMAD method templates, not project code)
- Ensures `_bmad/**`, `_bmad-output/**`, and `.claude/**` are all excluded
- Reduces scan noise and focuses analysis on actual source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality scanning configuration to exclude additional files from analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->