### PR TITLE
fix: add checkout step to Claude workflow for issue-triggered mode

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,10 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
       - name: Run Claude Code
         if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
         uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89


### PR DESCRIPTION
## Summary

- Adds `actions/checkout` step before `claude-code-action` so the runner has a git repository
- Issue-triggered runs were failing with `fatal: not a git repository` because the action's internal `git fetch origin main --depth=1` requires the repo to already be cloned
- Uses org-standard pinned SHA for checkout (`actions/checkout@v6.0.2`)

## Root cause

The `claude-code-action` composite action does not include its own checkout step. It runs `git fetch` and `git checkout` internally during branch setup, but these commands require a git repository to already exist on the runner. PR-triggered runs worked because GitHub Actions implicitly merges the PR ref, but issue-triggered runs start with an empty workspace.

## Test plan

- [ ] After merge, re-apply `claude` label to an issue and verify the workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)