### PR TITLE
feat(infra): add code-quality ruleset as Terraform IaC

### DIFF
--- a/infra/terraform/github/main.tf
+++ b/infra/terraform/github/main.tf
@@ -1,0 +1,83 @@
+# GitHub Repository Settings — Terraform
+#
+# Manages GitHub repository rulesets for petry-projects/broodly.
+# Apply with a GitHub token that has `administration:write` scope on this repo:
+#
+#   export TF_VAR_github_token=<your-token>
+#   terraform init
+#   terraform apply
+#
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/github-settings.md
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+# -----------------------------------------------------------------------------
+# code-quality ruleset
+#
+# Enforces required CI status checks on the default branch before merging.
+# Standard: github-settings.md#code-quality--required-checks-ruleset-all-repositories
+# -----------------------------------------------------------------------------
+
+resource "github_repository_ruleset" "code_quality" {
+  name        = "code-quality"
+  repository  = var.repository_name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  rules {
+    required_status_checks {
+      strict_required_status_checks_policy = false
+
+      required_check {
+        context        = "CI / TypeScript"
+        integration_id = 15368 # GitHub Actions app ID
+      }
+
+      required_check {
+        context        = "CI / Go"
+        integration_id = 15368
+      }
+
+      required_check {
+        context        = "CodeQL / Analyze"
+        integration_id = 15368
+      }
+
+      required_check {
+        context        = "SonarCloud Analysis / SonarCloud"
+        integration_id = 15368
+      }
+
+      required_check {
+        context        = "Dependency audit / pnpm audit"
+        integration_id = 15368
+      }
+
+      required_check {
+        context        = "Dependency audit / govulncheck"
+        integration_id = 15368
+      }
+    }
+  }
+}

--- a/infra/terraform/github/outputs.tf
+++ b/infra/terraform/github/outputs.tf
@@ -1,0 +1,4 @@
+output "code_quality_ruleset_id" {
+  description = "The ID of the code-quality repository ruleset"
+  value       = github_repository_ruleset.code_quality.ruleset_id
+}

--- a/infra/terraform/github/variables.tf
+++ b/infra/terraform/github/variables.tf
@@ -1,0 +1,17 @@
+variable "github_token" {
+  description = "GitHub personal access token with administration:write scope"
+  type        = string
+  sensitive   = true
+}
+
+variable "github_owner" {
+  description = "GitHub organization or user name"
+  type        = string
+  default     = "petry-projects"
+}
+
+variable "repository_name" {
+  description = "GitHub repository name"
+  type        = string
+  default     = "broodly"
+}


### PR DESCRIPTION
## Summary

- Adds `infra/terraform/github/` to manage the required `code-quality` repository ruleset via Infrastructure-as-Code
- The ruleset enforces required CI status checks (TypeScript, Go, CodeQL, SonarCloud, dependency audit) on the default branch
- Fixes the compliance finding from the weekly audit

## Why Terraform?

The `code-quality` ruleset is a GitHub repository settings object. The Claude Code workflow does not have `administration:write` permission and cannot create it via API. This IaC approach:
1. Documents the intended ruleset configuration in version-controlled code
2. Allows a repo admin to apply it with a single `terraform apply`

## How to apply

```bash
export TF_VAR_github_token=<github-pat-with-administration-write>
cd infra/terraform/github
terraform init
terraform apply
```

Once applied, the `code-quality` ruleset will exist in the repository settings and the weekly compliance audit will pass.

## Required status checks configured

| Check | Workflow |
|-------|----------|
| `CI / TypeScript` | `.github/workflows/ci.yml` |
| `CI / Go` | `.github/workflows/ci.yml` |
| `CodeQL / Analyze` | `.github/workflows/codeql.yml` |
| `SonarCloud Analysis / SonarCloud` | `.github/workflows/sonarcloud.yml` |
| `Dependency audit / pnpm audit` | `.github/workflows/dependency-audit.yml` |
| `Dependency audit / govulncheck` | `.github/workflows/dependency-audit.yml` |

> **Note:** If the org standard specifies different check names, update `infra/terraform/github/main.tf` before applying.

Closes #67

Generated with [Claude Code](https://claude.ai/code)