### PR TITLE
fix: enable GitHub Discussions via probot/settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -2,8 +2,11 @@
 # https://github.com/apps/settings
 #
 # This file brings the repository into compliance with the
-# petry-projects label standard:
-# https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#labels--standard-set
+# petry-projects organization standards:
+# https://github.com/petry-projects/.github/blob/main/standards/github-settings.md
+
+repository:
+  has_discussions: true
 
 labels:
   - name: security


### PR DESCRIPTION
## Summary

- Adds `repository.has_discussions: true` to `.github/settings.yml` so the probot/settings app will enable Discussions when this PR is merged
- Broadens the comment header to reference the full org standards doc (not just labels)

## Why

The weekly compliance audit flagged `has_discussions` as `null` (expected `true`). Previous automated fix attempts were blocked because direct `gh api` calls require admin credentials not available to the job. Using the existing probot/settings integration is the right declarative approach — it requires no elevated permissions at merge time.

## How it works

The [probot/settings](https://github.com/apps/settings) app watches for changes to `.github/settings.yml` and applies repository settings automatically on push/merge. Adding `has_discussions: true` under the `repository` key will toggle Discussions on.

Closes #78

Generated with [Claude Code](https://claude.ai/code)