### PR TITLE
ci: add agent-shield.yml workflow

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -1,0 +1,19 @@
+# Agent Shield — thin caller that delegates to the org-level reusable workflow.
+# All logic is maintained centrally in agent-shield-reusable.yml.
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#required-workflows
+name: Agent Shield
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  agent-shield:
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@main
+    secrets: inherit
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
## Summary

- Adds the missing `agent-shield.yml` workflow required by the org CI standards
- Follows the thin-caller pattern used by all other org-managed workflows in this repo (`claude.yml`, `feature-ideation.yml`, etc.)
- Delegates all logic to `petry-projects/.github/.github/workflows/agent-shield-reusable.yml@main`

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, the weekly compliance audit should no longer flag `missing-agent-shield.yml`

Closes #74

Generated with [Claude Code](https://claude.ai/code)