### PR TITLE
fix: pin dtolnay/rust-toolchain to SHA for action-pinning compliance

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -157,7 +157,9 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@bfc5673f3d7b9c42f04f9b5fb4fc3a3e10e91b6d # stable
+        with:
+          toolchain: stable
 
       - name: Install cargo-audit
         run: cargo install cargo-audit@0.21.1 --locked


### PR DESCRIPTION
## Summary

- Pin `dtolnay/rust-toolchain@stable` to immutable commit SHA `bfc5673f3d7b9c42f04f9b5fb4fc3a3e10e91b6d` in `.github/workflows/dependency-audit.yml`
- Add explicit `toolchain: stable` input to preserve existing behavior (required when pinning to a SHA, as the action can no longer infer the channel from the ref)
- Dependabot (already configured for `github-actions`) will automatically update this SHA on its next weekly run

## Test plan

- [ ] Verify the workflow syntax is valid
- [ ] Confirm the compliance audit no longer flags this action as unpinned

Closes #63

Generated with [Claude Code](https://claude.ai/code)