### PR TITLE
fix(api): bump Go toolchain to 1.26.2 for stdlib CVE fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           cache-dependency-path: apps/api/go.sum
 
       - name: Vet
@@ -59,6 +59,13 @@ jobs:
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           working-directory: apps/api
+          # Pin golangci-lint to a release built with Go >= 1.26 so it
+          # can read the toolchain pin in apps/api/go.mod (go1.26.2).
+          # The action's default is built with Go 1.24 and refuses with:
+          #   "the Go language version (go1.24) used to build
+          #    golangci-lint is lower than the targeted Go version
+          #    (1.26.2)"
+          version: v2.11.4
 
       - name: Test
         run: go test ./... -race -coverprofile=coverage.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: go vet ./...
 
       - name: Lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           working-directory: apps/api
           # Pin golangci-lint to a release built with Go >= 1.26 so it

--- a/apps/api/cmd/server/main.go
+++ b/apps/api/cmd/server/main.go
@@ -16,7 +16,9 @@ func main() {
 
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"status":"ok"}`)
+		if _, err := fmt.Fprintf(w, `{"status":"ok"}`); err != nil {
+			log.Printf("health check: write response: %v", err)
+		}
 	})
 
 	addr := ":8080"

--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -2,4 +2,10 @@ module github.com/broodly/api
 
 go 1.24
 
+// Force toolchain to a Go version that includes the fixes for
+// GO-2026-4866, GO-2026-4870, GO-2026-4946, GO-2026-4947 (all crypto/tls
+// and crypto/x509 stdlib fixes shipped in 1.26.2). The `go` directive
+// stays at 1.24 because no language features above that are used.
+toolchain go1.26.2
+
 require github.com/go-chi/chi/v5 v5.2.2


### PR DESCRIPTION
Closes #95.

Adds `toolchain go1.26.2` to `apps/api/go.mod` so the build pulls a Go release that includes the fixes for four standard-library vulnerabilities flagged by govulncheck on main:

| ID | Affected | Fix |
|---|---|---|
| **GO-2026-4866** | crypto/x509 — case-sensitive excludedSubtrees name constraints (auth bypass) | go1.26.2 |
| **GO-2026-4870** | crypto/tls — unauthenticated TLS 1.3 KeyUpdate record (DoS) | go1.26.2 |
| **GO-2026-4946** | crypto/x509 — inefficient policy validation | go1.26.2 |
| **GO-2026-4947** | crypto/x509 — unexpected work during chain building | go1.26.2 |

The `go` directive stays at 1.24 because no language features above that version are used; only the toolchain pin is bumped.

## Test plan

- [x] `go mod tidy` clean locally on go1.26.2
- [x] `go vet ./...` clean
- [ ] CI on this branch — `dependency-audit / govulncheck` should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build toolchain configuration to ensure consistent compilation environment across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->