### PR TITLE
ci: add agent-shield.yml workflow

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -1,0 +1,33 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/agent-shield.yml
+# Standard:        petry-projects/.github/standards/agent-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/agent-shield-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. The AgentShield CLI scan and the
+#     org-specific structural checks live in the reusable workflow above.
+#   • You MAY change: the `with:` inputs (min-severity, agentshield-version,
+#     required-files, org-standards-ref) — only if your repo genuinely needs
+#     a different policy.
+#   • You MUST NOT change: trigger events, the `uses:` line, or the job name
+#     (used as a required status check).
+#   • If you need different behaviour beyond the inputs, open a PR against
+#     the reusable in the central repo.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# AgentShield — thin caller for the org-level reusable.
+# To adopt: copy this file to .github/workflows/agent-shield.yml in your repo.
+name: AgentShield
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  agent-shield:
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1


### PR DESCRIPTION
## Summary

- Adds the required `agent-shield.yml` workflow, copied verbatim from the org standard template at `petry-projects/.github/standards/workflows/agent-shield.yml`
- Thin-caller stub that delegates all logic to `petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1`
- Triggers on `push` and `pull_request` to `main`, with `contents: read` permissions only

Closes #74

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented AgentShield automated workflow that runs security and quality checks on code changes to the main branch via pull requests and commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->