### PR TITLE
ci: pin claude-code-reusable workflow call to SHA

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@ae9709f4466dec60a5733c9e7487f69dcd004e05 # v1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/claude-code-reusable.yml` from `@v1` tag to commit SHA `ae9709f4466dec60a5733c9e7487f69dcd004e05` (v1)
- Resolves the `unpinned-actions-claude.yml` compliance finding from the weekly audit

## Rationale

The [Action Pinning Policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy) requires all workflow `uses:` references to be pinned to a specific commit SHA. The SHA was resolved by dereferencing the annotated `v1` tag:

```bash
gh api repos/petry-projects/.github/git/refs/tags/v1 --jq '.object.sha'
# → 208ec2d69b75227d375edf8745d84fbac05a76b2  (tag object)
gh api repos/petry-projects/.github/git/tags/208ec2d69b75227d375edf8745d84fbac05a76b2 --jq '.object.sha'
# → ae9709f4466dec60a5733c9e7487f69dcd004e05  (commit SHA)
```

Closes #100

Generated with [Claude Code](https://claude.ai/code)