### PR TITLE
ci: pin dependabot-rebase-reusable.yml to SHA (v1)

### DIFF
--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -39,5 +39,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@208ec2d69b75227d375edf8745d84fbac05a76b2 # v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Pins the reusable workflow reference in `.github/workflows/dependabot-rebase.yml` from the mutable `@v1` tag to its corresponding commit SHA (`208ec2d69b75227d375edf8745d84fbac05a76b2`) per the org [action-pinning policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy)
- No logic change — this is a compliance-only fix

Closes #102

Generated with [Claude Code](https://claude.ai/code)