### PR TITLE
fix: add *.pem to .gitignore for push-protection compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ apps/mobile/web-build/
 *.jks
 *.p8
 *.p12
+*.pem
 *.key
 *.mobileprovision
 *.orig.*


### PR DESCRIPTION
## Summary

- Adds `*.pem` to `.gitignore` to satisfy the org push-protection baseline (`gitignore_secrets_block` compliance check)
- Pattern placed alongside other key/cert entries (`*.jks`, `*.p8`, `*.p12`, `*.key`) in the Expo section

## Standard Reference

[standards/push-protection.md#required-gitignore-entries](https://github.com/petry-projects/.github/blob/main/standards/push-protection.md#required-gitignore-entries)

Closes #113

Generated with [Claude Code](https://claude.ai/code)