### PR TITLE
fix: add workflow_dispatch trigger to dependabot-rebase workflow

### DIFF
--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -28,6 +28,8 @@ on:
     branches:
       - main
 
+  workflow_dispatch: # allow manual trigger to flush Dependabot PR queue
+
 concurrency:
   group: dependabot-update-and-merge
   cancel-in-progress: false


### PR DESCRIPTION
Adds `workflow_dispatch` to allow manual triggering of the Dependabot rebase workflow to flush the PR queue after batch updates. See petry-projects/.github#139