### PR TITLE
ci: pin claude-code-reusable workflow call to SHA

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,12 +31,14 @@ on:
     types: [created]
   issues:
     types: [labeled]
+  check_run:
+    types: [completed]
 
 permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/claude-code-reusable.yml` from `@v1` to commit SHA `ee22b427cbce9ecadcf2b436acb57c3adf0cb63d` (v1) per [Action Pinning Policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy)
- Syncs file to canonical template: adds `check_run: types: [completed]` trigger that was present in `petry-projects/.github/standards/workflows/claude.yml` but missing from this repo's copy

**Change:**
\`\`\`yaml
# Before
uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1

# After
uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1
\`\`\`

**Note:** A previous PR (#117) pinned to an older SHA (`ae9709f4466dec60a5733c9e7487f69dcd004e05`). The v1 tag has since been updated to `ee22b427cbce9ecadcf2b436acb57c3adf0cb63d`, so this PR uses the current SHA.

Closes #100

Generated with [Claude Code](https://claude.ai/code)