### PR TITLE
fix: remove duplicate .github/ segment from reusable workflow references

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/agent-shield.yml
 # Standard:        petry-projects/.github/standards/agent-standards.md
-# Reusable:        petry-projects/.github/.github/workflows/agent-shield-reusable.yml
+# Reusable:        petry-projects/.github/workflows/agent-shield-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. The AgentShield CLI scan and the
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/workflows/agent-shield-reusable.yml@v1

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependabot-automerge.yml
 # Standard:        petry-projects/.github/standards/dependabot-policy.md
-# Reusable:        petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml
+# Reusable:        petry-projects/.github/workflows/dependabot-automerge-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All eligibility logic and the GitHub
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
+    uses: petry-projects/.github/workflows/dependabot-automerge-reusable.yml@v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Fixes compliance finding `reusable-workflow-path-duplicate-github` (issue #158)
- `agent-shield.yml`: changed `uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1` → `petry-projects/.github/workflows/agent-shield-reusable.yml@v1`
- `dependabot-automerge.yml`: same fix for `dependabot-automerge-reusable.yml`
- Also updated the `# Reusable:` header comment in both files to match

## Root cause

Both thin caller stubs had a duplicate `.github/` path segment in their `uses:` reference. When calling a reusable workflow in the `petry-projects/.github` repository, the correct syntax is `petry-projects/.github/workflows/<workflow>.yml@<ref>`, not `petry-projects/.github/.github/workflows/<workflow>.yml@<ref>`.

## Test plan

- [ ] AgentShield CI job passes on this PR
- [ ] Dependabot auto-merge workflow resolves on the next Dependabot PR
- [ ] Next weekly compliance audit does not re-flag `reusable-workflow-path-duplicate-github`

Closes #158

Generated with [Claude Code](https://claude.ai/code)