### PR TITLE
fix: replace SHA-pinned auto-rebase stub with canonical @v1 reference

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -38,5 +38,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@126c1441ee9cf040f2ce3ef0eda85d459b82f8e9 # v1
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Replaces `@126c1441ee9cf040f2ce3ef0eda85d459b82f8e9 # v1` SHA pin with the org-standard `@v1` tag reference in `.github/workflows/auto-rebase.yml`
- File now matches the canonical stub from `petry-projects/.github/standards/workflows/auto-rebase.yml` verbatim
- No functional change — same reusable workflow, corrected reference format

## Standard Reference

[standards/ci-standards.md#centralization-tiers](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#centralization-tiers)

Closes #165

Generated with [Claude Code](https://claude.ai/code)