### PR TITLE
fix(ci): pin auto-rebase reusable workflow to SHA

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -38,5 +38,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@126c1441ee9cf040f2ce3ef0eda85d459b82f8e9 # v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/auto-rebase-reusable.yml` from the floating `@v1` tag to its commit SHA (`126c1441ee9cf040f2ce3ef0eda85d459b82f8e9`) in `.github/workflows/auto-rebase.yml`
- The `# v1` comment is preserved for human readability
- No other changes — the file is a thin caller stub and only the `uses:` SHA may be changed per its own AGENTS comment

## Motivation

Satisfies the org [action-pinning policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy) flagged by the weekly compliance audit.

Closes #167

## Test plan

- [ ] CI passes on this PR
- [ ] Compliance audit no longer flags `auto-rebase.yml` after merge

Generated with [Claude Code](https://claude.ai/code)