### PR TITLE
chore: add bot accounts to CODEOWNERS for auto-merge support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,19 +3,19 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owner for all files
-* @don-petry
+* @don-petry @petry-projects-pr-review-agent @dependabot-automerge-petry
 
 # Mobile app
-/apps/mobile/ @don-petry
+/apps/mobile/ @don-petry @petry-projects-pr-review-agent @dependabot-automerge-petry
 
 # API server
-/apps/api/ @don-petry
+/apps/api/ @don-petry @petry-projects-pr-review-agent @dependabot-automerge-petry
 
 # Shared packages
-/packages/ @don-petry
+/packages/ @don-petry @petry-projects-pr-review-agent @dependabot-automerge-petry
 
 # Infrastructure
-/infra/ @don-petry
+/infra/ @don-petry @petry-projects-pr-review-agent @dependabot-automerge-petry
 
 # CI/CD and GitHub configuration
-/.github/ @don-petry
+/.github/ @don-petry @petry-projects-pr-review-agent @dependabot-automerge-petry


### PR DESCRIPTION
## Summary

Add \`@petry-projects-pr-review-agent\` and \`@dependabot-automerge-petry\` to CODEOWNERS so bot approvals satisfy the \`require_code_owner_review\` setting in the \`pr-quality\` ruleset.

## Why

Dependabot PRs were stuck at \`REVIEW_REQUIRED\` — the auto-merge bot was approving but isn't listed as a code owner. See [petry-projects/.github#180](https://github.com/petry-projects/.github/pull/180) for the org standard this implements.

## Test plan
- [ ] Confirm existing open Dependabot PRs unblock and auto-merge after this merges