### PR TITLE
feat(copilot): add repo-level Copilot instruction files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,14 +36,14 @@ packages/
 
 ## Local Dev Commands
 
-- Install:    `pnpm install`
+- Install: `pnpm install`
 - Test (JS/TS): `pnpm test`
 - Test (Go API): `cd apps/api && go test ./...`
 - Lint (JS/TS): `pnpm lint`
 - Lint (Go API): `cd apps/api && golangci-lint run`
-- Typecheck:  `pnpm typecheck`
+- Typecheck: `pnpm typecheck`
 - Mobile dev: `pnpm --filter mobile start`
-- API dev:    `cd apps/api && go run ./cmd/server`
+- API dev: `cd apps/api && go run ./cmd/server`
 
 ## Environment Variables (API server)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -60,4 +60,10 @@ packages/
 
 ## Org Standards
 
-See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md).
+See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md) for org-wide development standards.
+
+**Language-specific instructions** (applied automatically by Copilot when you open matching file types):
+
+- [TypeScript / TSX](.github/instructions/typescript.instructions.md) — strict config, branded types, DDD/CQRS patterns, React, pino logging
+- [JavaScript](.github/instructions/javascript.instructions.md) — style, JSDoc type annotations, error handling
+- [Go](.github/instructions/go.instructions.md) — naming, gofmt, slog logging, error wrapping, concurrency, testing

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # Copilot Instructions — broodly
 
 > **Note:** This file applies to the `petry-projects/broodly` repository only. Org-wide Copilot
-> rules are in [`petry-projects/.github/copilot-instructions.md`](https://github.com/petry-projects/.github/blob/main/.github/copilot-instructions.md).
+> rules are in [`petry-projects/.github/copilot-instructions.md`](https://github.com/petry-projects/.github/blob/main/copilot-instructions.md).
 > Comprehensive agent/AI coding standards (including TDD, architecture, and BMAD workflow) are
 > in [`petry-projects/.github/AGENTS.md`](https://github.com/petry-projects/.github/blob/main/AGENTS.md).
 > This file covers only what is specific to broodly.
@@ -29,7 +29,9 @@ packages/
   domain-types/        # Shared TypeScript domain types
   graphql-types/       # @graphql-codegen generated types (never edit directly)
   test-utils/          # Shared test helpers
-  ui/                  # Shared Gluestack UI components
+  ui/                  # Shared UI components (note: Gluestack-generated components currently
+                       #   live in apps/mobile/components/ui — add react/react-native/gluestack
+                       #   deps to this package before moving components here)
 ```
 
 ## Local Dev Commands
@@ -37,7 +39,8 @@ packages/
 - Install:    `pnpm install`
 - Test (JS/TS): `pnpm test`
 - Test (Go API): `cd apps/api && go test ./...`
-- Lint (all): `pnpm lint`
+- Lint (JS/TS): `pnpm lint`
+- Lint (Go API): `cd apps/api && golangci-lint run`
 - Typecheck:  `pnpm typecheck`
 - Mobile dev: `pnpm --filter mobile start`
 - API dev:    `cd apps/api && go run ./cmd/server`
@@ -48,8 +51,7 @@ These are required when running the Go API server locally; they are not needed f
 package development or mobile-only work:
 
 - `FIREBASE_PROJECT_ID`: GCP Firebase project ID
-- `FIREBASE_API_KEY`: Firebase web API key
-- `CLOUD_SQL_URL`: PostgreSQL connection string (Cloud SQL proxy for local dev)
+- `DATABASE_URL`: PostgreSQL connection string (Cloud SQL proxy for local dev; matches the Cloud Run secret binding)
 
 ## Testing Framework
 
@@ -69,7 +71,7 @@ package development or mobile-only work:
 ## Org Standards
 
 See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md) for org-wide agent/AI coding standards (TDD, architecture, BMAD workflow).
-See [petry-projects/.github/copilot-instructions.md](https://github.com/petry-projects/.github/blob/main/.github/copilot-instructions.md) for org-wide Copilot instructions.
+See [petry-projects/.github/copilot-instructions.md](https://github.com/petry-projects/.github/blob/main/copilot-instructions.md) for org-wide Copilot instructions.
 
 **Language-specific instructions** (applied automatically by Copilot when you open matching file types):
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,63 @@
+# Copilot Instructions — broodly
+
+> **Note:** This file applies to the `petry-projects/broodly` repository only. Org-wide rules are in [`petry-projects/.github/copilot-instructions.md`](https://github.com/petry-projects/.github/blob/main/.github/copilot-instructions.md). This file covers only what is specific to broodly.
+
+## About
+
+Broodly is a field-first beekeeping decision-support app — a pnpm monorepo with an Expo React Native mobile frontend and a Go backend, helping beekeepers make data-driven hive management decisions.
+
+## Tech Stack
+
+- **Runtime:** Node.js ≥ 20 (mobile/packages) · Go 1.24 / toolchain go1.26.2 (API)
+- **Framework:** Expo SDK 55 · React Native 0.83 · React 19 · Gluestack UI v3 · NativeWind v4
+- **Testing:** Jest with jest-expo preset (mobile) · React Testing Library for Native · `go test ./...` (API)
+- **Linting:** ESLint ^10 + Prettier ^3 (root workspace) · `golangci-lint` (Go)
+- **Key libraries:** `@gluestack-ui/core` ^3, `nativewind` ^4, `react-native-reanimated` ^4, `go-chi/chi` v5, TypeScript ~5.9.3
+
+## Project Structure
+
+```text
+apps/
+  mobile/              # Expo React Native app (Expo SDK 55, jest-expo)
+  api/                 # Go backend (go.mod: github.com/broodly/api, chi router)
+packages/
+  config/              # Shared ESLint / TypeScript config
+  domain-types/        # Shared TypeScript domain types
+  graphql-types/       # @graphql-codegen generated types (never edit directly)
+  test-utils/          # Shared test helpers
+  ui/                  # Shared Gluestack UI components
+```
+
+## Local Dev Commands
+
+- Install:    `pnpm install`
+- Test (all): `pnpm test`
+- Lint (all): `pnpm lint`
+- Typecheck:  `pnpm typecheck`
+- Mobile dev: `pnpm --filter mobile start`
+- API dev:    `cd apps/api && go run ./cmd/...`
+
+## Required Environment Variables
+
+- `FIREBASE_PROJECT_ID`: GCP Firebase project ID
+- `FIREBASE_API_KEY`: Firebase web API key
+- `CLOUD_SQL_URL`: PostgreSQL connection string (Cloud SQL proxy for local dev)
+
+## Testing Framework
+
+- Mobile runner: Jest with jest-expo preset; React Testing Library (`@testing-library/react-native`)
+- API runner: `go test ./...` with `golangci-lint run`
+- Coverage thresholds: defined per-package (see each `jest.config.js`)
+- Mutation testing: not configured
+
+## Repo-Specific Overrides
+
+**pnpm workspace** — always run commands from the monorepo root using `pnpm -r` or `pnpm --filter <package>`. Do not `cd` into packages and run `npm` directly.
+
+**Cross-package imports** — use workspace package names (`@broodly/domain-types`, `@broodly/ui`) declared in `package.json` workspaces; never use relative paths across package boundaries.
+
+**Go module** — the API module is `github.com/broodly/api` with toolchain pinned to go1.26.2 for crypto/tls security fixes; the `go` directive stays at 1.24.
+
+## Org Standards
+
+See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,10 @@
 # Copilot Instructions — broodly
 
-> **Note:** This file applies to the `petry-projects/broodly` repository only. Org-wide rules are in [`petry-projects/.github/copilot-instructions.md`](https://github.com/petry-projects/.github/blob/main/.github/copilot-instructions.md). This file covers only what is specific to broodly.
+> **Note:** This file applies to the `petry-projects/broodly` repository only. Org-wide Copilot
+> rules are in [`petry-projects/.github/copilot-instructions.md`](https://github.com/petry-projects/.github/blob/main/.github/copilot-instructions.md).
+> Comprehensive agent/AI coding standards (including TDD, architecture, and BMAD workflow) are
+> in [`petry-projects/.github/AGENTS.md`](https://github.com/petry-projects/.github/blob/main/AGENTS.md).
+> This file covers only what is specific to broodly.
 
 ## About
 
@@ -31,13 +35,17 @@ packages/
 ## Local Dev Commands
 
 - Install:    `pnpm install`
-- Test (all): `pnpm test`
+- Test (JS/TS): `pnpm test`
+- Test (Go API): `cd apps/api && go test ./...`
 - Lint (all): `pnpm lint`
 - Typecheck:  `pnpm typecheck`
 - Mobile dev: `pnpm --filter mobile start`
-- API dev:    `cd apps/api && go run ./cmd/...`
+- API dev:    `cd apps/api && go run ./cmd/server`
 
-## Required Environment Variables
+## Environment Variables (API server)
+
+These are required when running the Go API server locally; they are not needed for JS/TS
+package development or mobile-only work:
 
 - `FIREBASE_PROJECT_ID`: GCP Firebase project ID
 - `FIREBASE_API_KEY`: Firebase web API key
@@ -46,8 +54,8 @@ packages/
 ## Testing Framework
 
 - Mobile runner: Jest with jest-expo preset; React Testing Library (`@testing-library/react-native`)
-- API runner: `go test ./...` with `golangci-lint run`
-- Coverage thresholds: defined per-package (see each `jest.config.js`)
+- API runner: `cd apps/api && go test ./...` with `golangci-lint run`
+- Coverage thresholds: defined per-package (see each package's `jest.config.js`; mobile config is in `apps/mobile/package.json`)
 - Mutation testing: not configured
 
 ## Repo-Specific Overrides
@@ -60,10 +68,11 @@ packages/
 
 ## Org Standards
 
-See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md) for org-wide development standards.
+See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md) for org-wide agent/AI coding standards (TDD, architecture, BMAD workflow).
+See [petry-projects/.github/copilot-instructions.md](https://github.com/petry-projects/.github/blob/main/.github/copilot-instructions.md) for org-wide Copilot instructions.
 
 **Language-specific instructions** (applied automatically by Copilot when you open matching file types):
 
-- [TypeScript / TSX](.github/instructions/typescript.instructions.md) — strict config, branded types, DDD/CQRS patterns, React, pino logging
+- [TypeScript / TSX](.github/instructions/typescript.instructions.md) — strict config, branded types, DDD/CQRS patterns, React Native (`testID`)
 - [JavaScript](.github/instructions/javascript.instructions.md) — style, JSDoc type annotations, error handling
 - [Go](.github/instructions/go.instructions.md) — naming, gofmt, slog logging, error wrapping, concurrency, testing

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -81,7 +81,8 @@ logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 logger.InfoContext(ctx, "order placed", "order_id", orderID, "user_id", userID)
 ```
 
-- **Never use the global `log` package** from the standard library.
+- **Prefer `log/slog` over the global `log` package** for all new code. Migrate existing `log`
+  usages to `slog` incrementally — do not introduce new `log` calls.
 - Propagate loggers via `context.Context`. Use `slog.InfoContext(ctx, ...)` so trace/span IDs
   are automatically bridged.
 - In tests, suppress output: `slog.New(slog.NewTextHandler(io.Discard, nil))`.
@@ -113,10 +114,14 @@ logger.InfoContext(ctx, "order placed", "order_id", orderID, "user_id", userID)
   and create fresh readers: `bytes.NewReader(buf)`.
 - Set `req.GetBody` for retryable requests so the transport can recreate the body.
 
-## HTTP Server (net/http)
+## HTTP Server
 
-- Go ≥ 1.22: use the enhanced `net/http` `ServeMux` with method + pattern routing.
-- Go < 1.22: handle methods manually in handlers or use a justified third-party router.
+This repository's API uses **`go-chi/chi` v5** as the router. Write handlers and middleware
+targeting chi's `chi.Router` interface. Do not switch to `net/http` `ServeMux` for API code —
+chi is the established standard here.
+
+For standalone tools or packages outside the API that have no chi dependency, the enhanced
+`net/http` `ServeMux` (Go ≥ 1.22 method + pattern routing) is acceptable.
 
 ## Type Safety
 
@@ -148,7 +153,7 @@ logger.InfoContext(ctx, "order placed", "order_id", orderID, "user_id", userID)
 - `go fmt` — format code (non-negotiable)
 - `go vet` — find suspicious constructs
 - `golangci-lint` — extended linting (replaces deprecated `golint`)
-- `go test ./...` — run all tests
+- `go test ./...` — run all tests (run from the module root, e.g. `cd apps/api && go test ./...`)
 - `go mod tidy` — clean up unused dependencies
 
 Run `golangci-lint run` before committing. Zero warnings, zero errors.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,154 @@
+---
+description: Go development standards for the Petry Projects organization, based on Effective Go and Google's Go Style Guide
+applyTo: "**/*.go"
+---
+
+# Go Development Standards
+
+These rules extend the org-level `copilot-instructions.md`. They are based on
+[Effective Go](https://go.dev/doc/effective_go),
+[Go Code Review Comments](https://go.dev/wiki/CodeReviewComments), and
+[Google's Go Style Guide](https://google.github.io/styleguide/go/). Go is used for
+infrastructure tools, CLI utilities, and backend services in this org.
+
+## General Principles
+
+- Write simple, clear, and idiomatic Go. Favor clarity over cleverness.
+- Keep the happy path left-aligned — return early to reduce nesting.
+- Make the zero value useful. Design types so the zero value is a valid, safe starting state.
+- Prefer the standard library over third-party packages when equivalent functionality exists.
+- Use Go modules (`go.mod` / `go.sum`) for all dependency management.
+
+## Naming Conventions
+
+- Package names: lowercase, single-word, no underscores or hyphens. Singular, not plural.
+  Avoid generic names (`util`, `common`, `base`, `helper`).
+- Variables and functions: `camelCase`. Exported symbols: `PascalCase`.
+- Interfaces: `-er` suffix when describing a single behavior (`Reader`, `Writer`, `Formatter`).
+  Keep interfaces small (1–3 methods is ideal).
+- **Each Go file must have exactly ONE `package` declaration.** When editing an existing file,
+  preserve the existing declaration. When creating a new file, check the package names of
+  sibling files first.
+
+## Code Style
+
+- Always format with `gofmt` (or `goimports`). This is non-negotiable.
+- Use `goimports` to manage import blocks automatically.
+- Write comments in English. Document all exported symbols — start with the symbol name.
+  Comment the *why*, not the *what*, unless the logic is complex.
+- Avoid emoji in code and comments.
+
+## Error Handling
+
+- Check errors immediately after every function call. Never ignore with `_` without a comment.
+- Wrap errors with context: `fmt.Errorf("operation description: %w", err)`.
+- Place error returns as the last return value, named `err`.
+- Use `errors.Is` / `errors.As` for error checking, not string comparison.
+- Log errors at the point of handling — not at every intermediate propagation layer. Add context
+  by wrapping, then log once at the top-level handler.
+- Error messages: lowercase, no trailing punctuation.
+
+## Project Structure
+
+Follow standard Go project layout:
+
+```text
+cmd/           # Application entry points (one directory per binary)
+internal/      # Private packages (not importable by external projects)
+pkg/           # Reusable packages safe for external import
+```
+
+Avoid circular dependencies. Use `internal/` for packages that should not be imported outside
+the module. Group related functionality into focused packages.
+
+## Structured Logging
+
+Use **`log/slog`** (Go 1.21+) as the default structured logger:
+
+```go
+import (
+    "log/slog"
+    "os"
+)
+
+// Wire up once at program start (e.g., main.go).
+// Production — structured JSON for log aggregation:
+logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+// Development — swap the handler for human-readable text:
+// logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+// Propagate the logger via context so OpenTelemetry can bridge trace/span IDs:
+logger.InfoContext(ctx, "order placed", "order_id", orderID, "user_id", userID)
+```
+
+- **Never use the global `log` package** from the standard library.
+- Propagate loggers via `context.Context`. Use `slog.InfoContext(ctx, ...)` so trace/span IDs
+  are automatically bridged.
+- In tests, suppress output: `slog.New(slog.NewTextHandler(io.Discard, nil))`.
+- Log at the point of handling, not at every layer. Wrap errors with `fmt.Errorf` and log once.
+- Never log variables named `password`, `secret`, `token`, `api_key`, `private_key`,
+  `authorization`, or `cookie`.
+
+## Concurrency
+
+- Be cautious about creating goroutines in libraries; prefer letting the caller control
+  concurrency.
+- Always know how a goroutine will exit. Use `sync.WaitGroup` or channels to wait for
+  goroutines. Avoid goroutine leaks.
+- Use channels for communication between goroutines; use `sync.Mutex` for protecting shared
+  state.
+- Close channels from the sender side only.
+- WaitGroup pattern:
+  - Go ≥ 1.25: `sync.WaitGroup` gains a `Go(fn func())` method — use `wg.Go(fn)` directly.
+  - Go < 1.25: use the classic `wg.Add(1)` / `defer wg.Done()` pattern.
+  - For error propagation across goroutines, prefer `golang.org/x/sync/errgroup` (`eg.Go(fn)`) over bare `sync.WaitGroup`.
+
+## HTTP Clients and I/O
+
+- HTTP client structs hold configuration only (base URL, `*http.Client`, auth, default headers).
+  Never store per-request state on the client struct.
+- Construct a fresh `*http.Request` per method call. Never cache or reuse a request object.
+- Always close response bodies: `defer resp.Body.Close()`.
+- `io.Reader` streams are consumable once. To read a body multiple times, use `io.ReadAll` once
+  and create fresh readers: `bytes.NewReader(buf)`.
+- Set `req.GetBody` for retryable requests so the transport can recreate the body.
+
+## HTTP Server (net/http)
+
+- Go ≥ 1.22: use the enhanced `net/http` `ServeMux` with method + pattern routing.
+- Go < 1.22: handle methods manually in handlers or use a justified third-party router.
+
+## Type Safety
+
+- Prefer explicit type conversions. Use `any` (Go 1.18+) instead of `interface{}`.
+- Use generics over unconstrained types. Prefer specific type constraints when possible.
+- Use type assertions carefully — always check the second return value:
+  `v, ok := x.(SomeType); if !ok { ... }`.
+
+## Testing
+
+- Use table-driven tests with `t.Run` subtests.
+- Name tests: `Test_FunctionName_Scenario` or `TestFunctionName`.
+- Mark helper functions with `t.Helper()`. Use `t.Cleanup()` for teardown.
+- Place test files next to source (`service.go` → `service_test.go`).
+- White-box tests use the same package; black-box tests use the `_test` package suffix.
+- Use `testify/assert` when it adds clarity, but avoid over-complicating simple assertions.
+
+## Security
+
+- Validate all external input at system boundaries.
+- Use `crypto/rand` for random number generation. Never use `math/rand` for security-sensitive
+  operations.
+- Use standard library `crypto` packages — never implement cryptographic algorithms.
+- Store passwords with bcrypt, scrypt, or argon2 (`golang.org/x/crypto`).
+- Use TLS for all network communication.
+
+## Tooling
+
+- `go fmt` — format code (non-negotiable)
+- `go vet` — find suspicious constructs
+- `golangci-lint` — extended linting (replaces deprecated `golint`)
+- `go test ./...` — run all tests
+- `go mod tidy` — clean up unused dependencies
+
+Run `golangci-lint run` before committing. Zero warnings, zero errors.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -151,10 +151,10 @@ For standalone tools or packages outside the API that have no chi dependency, th
 
 ## Tooling
 
-- `go fmt` — format code (non-negotiable)
+- `go fmt ./...` — format code (non-negotiable; run from `apps/api`, e.g. `cd apps/api && go fmt ./...`)
 - `go vet ./...` — find suspicious constructs (run from `apps/api`, e.g. `cd apps/api && go vet ./...`)
 - `golangci-lint` — extended linting (replaces deprecated `golint`)
 - `go test ./...` — run all tests (run from the module root, e.g. `cd apps/api && go test ./...`)
-- `go mod tidy` — clean up unused dependencies
+- `cd apps/api && go mod tidy` — clean up unused dependencies (the only Go module is under `apps/api`)
 
 Run `cd apps/api && golangci-lint run` before committing Go changes (the only Go module lives under `apps/api`, matching CI). Zero warnings, zero errors.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -83,8 +83,9 @@ logger.InfoContext(ctx, "order placed", "order_id", orderID, "user_id", userID)
 
 - **Prefer `log/slog` over the global `log` package** for all new code. Migrate existing `log`
   usages to `slog` incrementally — do not introduce new `log` calls.
-- Propagate loggers via `context.Context`. Use `slog.InfoContext(ctx, ...)` so trace/span IDs
-  are automatically bridged.
+- Propagate loggers via `context.Context`. Call `logger.InfoContext(ctx, ...)` on the configured
+  `*slog.Logger` instance (not the package-level `slog.InfoContext`) so request-scoped fields
+  and trace/span IDs are included.
 - In tests, suppress output: `slog.New(slog.NewTextHandler(io.Discard, nil))`.
 - Log at the point of handling, not at every layer. Wrap errors with `fmt.Errorf` and log once.
 - Never log variables named `password`, `secret`, `token`, `api_key`, `private_key`,
@@ -156,4 +157,4 @@ For standalone tools or packages outside the API that have no chi dependency, th
 - `go test ./...` — run all tests (run from the module root, e.g. `cd apps/api && go test ./...`)
 - `go mod tidy` — clean up unused dependencies
 
-Run `golangci-lint run` before committing. Zero warnings, zero errors.
+Run `cd apps/api && golangci-lint run` before committing Go changes (the only Go module lives under `apps/api`, matching CI). Zero warnings, zero errors.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -152,7 +152,7 @@ For standalone tools or packages outside the API that have no chi dependency, th
 ## Tooling
 
 - `go fmt` — format code (non-negotiable)
-- `go vet` — find suspicious constructs
+- `go vet ./...` — find suspicious constructs (run from `apps/api`, e.g. `cd apps/api && go vet ./...`)
 - `golangci-lint` — extended linting (replaces deprecated `golint`)
 - `go test ./...` — run all tests (run from the module root, e.g. `cd apps/api && go test ./...`)
 - `go mod tidy` — clean up unused dependencies

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: Go development standards for the Petry Projects organization, based on Effective Go and Google's Go Style Guide
-applyTo: "**/*.go"
+applyTo: '**/*.go'
 ---
 
 # Go Development Standards
@@ -35,7 +35,7 @@ infrastructure tools, CLI utilities, and backend services in this org.
 - Always format with `gofmt` (or `goimports`). This is non-negotiable.
 - Use `goimports` to manage import blocks automatically.
 - Write comments in English. Document all exported symbols — start with the symbol name.
-  Comment the *why*, not the *what*, unless the logic is complex.
+  Comment the _why_, not the _what_, unless the logic is complex.
 - Avoid emoji in code and comments.
 
 ## Error Handling

--- a/.github/instructions/javascript.instructions.md
+++ b/.github/instructions/javascript.instructions.md
@@ -1,0 +1,52 @@
+---
+description: JavaScript development standards for the Petry Projects organization
+applyTo: "**/*.js,**/*.mjs,**/*.cjs"
+---
+
+# JavaScript Development Standards
+
+These rules extend the org-level `copilot-instructions.md` and apply to JavaScript files.
+
+> **Prefer TypeScript.** If a file can be migrated to TypeScript without significant disruption,
+> prefer the migration. JavaScript is accepted for configuration files (`eslint.config.js`,
+> `vite.config.mjs`, `jest.config.js`), build scripts, and legacy code during migration.
+
+## Style and Formatting
+
+- **Formatter:** Prettier. Run `prettier --write` before committing.
+- **Linter:** ESLint. Zero warnings, zero errors.
+- Never use `var`. Use `const` for all bindings that are not reassigned; use `let` only when
+  reassignment is required.
+- Prefer `async`/`await` over raw `.then()`/`.catch()` chains. Handle rejections — never leave
+  a floating promise.
+- Use ES modules (`import`/`export`) in all new code. CommonJS (`require`/`module.exports`) is
+  acceptable only in config files that require it.
+- Use destructuring assignment to extract values from objects and arrays.
+
+## Naming Conventions
+
+- `camelCase` for variables and functions. `PascalCase` for constructors and classes.
+  `SCREAMING_SNAKE_CASE` for module-level constants.
+- File names match the primary export or purpose (`orderService.js`, `eslint.config.mjs`).
+
+## Type Safety Without TypeScript
+
+- Use JSDoc annotations (`@param`, `@returns`, `@type`) in JavaScript files that cannot yet be
+  migrated, to enable IDE type inference and `checkJs` validation.
+- Enable `// @ts-check` at the top of critical JavaScript files to surface type errors in the
+  IDE without requiring full TypeScript migration.
+
+## Error Handling
+
+- Always handle Promise rejections — either with `try`/`catch` in `async` functions or with an
+  explicit `.catch()` handler.
+- Never use empty catch blocks (`catch (e) {}`). At minimum, log the error with structured
+  fields.
+- Do not use `console.log` in application or library code. Use a structured logger (`pino`).
+  `console.*` is acceptable only in CLI scripts and build tooling.
+
+## Testing
+
+- Follow the same TDD rules as TypeScript: write tests before implementing, never `.skip()`.
+- Use the same test runner as the rest of the project (Vitest or Jest).
+- Name tests as functional requirement specifications.

--- a/.github/instructions/javascript.instructions.md
+++ b/.github/instructions/javascript.instructions.md
@@ -1,6 +1,9 @@
 ---
 description: JavaScript development standards for the Petry Projects organization
-applyTo: "**/*.js,**/*.mjs,**/*.cjs"
+applyTo:
+  - "**/*.js"
+  - "**/*.mjs"
+  - "**/*.cjs"
 ---
 
 # JavaScript Development Standards
@@ -42,7 +45,8 @@ These rules extend the org-level `copilot-instructions.md` and apply to JavaScri
   explicit `.catch()` handler.
 - Never use empty catch blocks (`catch (e) {}`). At minimum, log the error with structured
   fields.
-- Do not use `console.log` in application or library code. Use a structured logger (`pino`).
+- Do not use `console.log` in application or library code. Use a structured logger (`pino` for
+  Node.js server/backend code; add it as an explicit dependency per package).
   `console.*` is acceptable only in CLI scripts and build tooling.
 
 ## Testing

--- a/.github/instructions/javascript.instructions.md
+++ b/.github/instructions/javascript.instructions.md
@@ -1,9 +1,9 @@
 ---
 description: JavaScript development standards for the Petry Projects organization
 applyTo:
-  - "**/*.js"
-  - "**/*.mjs"
-  - "**/*.cjs"
+  - '**/*.js'
+  - '**/*.mjs'
+  - '**/*.cjs'
 ---
 
 # JavaScript Development Standards
@@ -16,7 +16,7 @@ These rules extend the org-level `copilot-instructions.md` and apply to JavaScri
 
 ## Style and Formatting
 
-- **Formatter:** Prettier. Run `prettier --write` before committing.
+- **Formatter:** Prettier. Run `pnpm format` before committing.
 - **Linter:** ESLint. Zero warnings, zero errors.
 - Never use `var`. Use `const` for all bindings that are not reassigned; use `let` only when
   reassignment is required.

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: TypeScript and TSX development standards for the Petry Projects organization
-applyTo: "**/*.ts,**/*.tsx"
+applyTo: '**/*.ts,**/*.tsx'
 ---
 
 # TypeScript Development Standards
@@ -38,7 +38,7 @@ reason. Fix the underlying type issue instead.
 ## Code Style
 
 - **Formatter:** Prettier with `singleQuote: true`, `semi: true`, `trailingComma: "all"`,
-  `printWidth: 100`, `tabWidth: 2`. Run `prettier --write` before committing.
+  `printWidth: 100`, `tabWidth: 2`. Run `pnpm format` before committing.
 - **Linter:** ESLint flat config (`eslint.config.js`). Zero warnings, zero errors.
 - **Imports:** Use `import type { ... }` for type-only imports. Organize imports: external
   packages first, then internal modules. No circular imports.
@@ -57,8 +57,8 @@ reason. Fix the underlying type issue instead.
 - Use branded types / nominal typing for domain identifiers and value objects:
 
   ```typescript
-  type UserId = string & { readonly __brand: "UserId" };
-  type OrderId = string & { readonly __brand: "OrderId" };
+  type UserId = string & { readonly __brand: 'UserId' };
+  type OrderId = string & { readonly __brand: 'OrderId' };
   ```
 
 - Use discriminated unions instead of optional fields where possible.
@@ -83,13 +83,13 @@ reason. Fix the underlying type issue instead.
 
 ## CQRS Naming Conventions
 
-| Concept | Convention | Examples |
-|---------|-----------|----------|
-| Command | Imperative verb + noun | `PlaceOrder`, `CancelSubscription` |
-| Event | Past-tense verb + noun | `OrderPlaced`, `SubscriptionCancelled` |
-| Query | `Get` / `List` / `Search` + noun | `GetOrderById`, `ListActiveUsers` |
-| Command handler | `Handle(cmd)` or `<Name>Handler` | `PlaceOrderHandler` |
-| Projection | Noun describing the view | `OrderSummaryProjection` |
+| Concept         | Convention                       | Examples                               |
+| --------------- | -------------------------------- | -------------------------------------- |
+| Command         | Imperative verb + noun           | `PlaceOrder`, `CancelSubscription`     |
+| Event           | Past-tense verb + noun           | `OrderPlaced`, `SubscriptionCancelled` |
+| Query           | `Get` / `List` / `Search` + noun | `GetOrderById`, `ListActiveUsers`      |
+| Command handler | `Handle(cmd)` or `<Name>Handler` | `PlaceOrderHandler`                    |
+| Projection      | Noun describing the view         | `OrderSummaryProjection`               |
 
 Commands MUST NOT return domain data — return the new entity ID or void. Queries MUST NOT
 mutate state.
@@ -101,15 +101,15 @@ explicit dependency). Never use `console.log`, `console.error`, or `console.warn
 application or library code (`console.*` is acceptable only in CLI tools and build scripts):
 
 ```typescript
-import pino from "pino";
+import pino from 'pino';
 const logger = pino();
 
 // In Express/Fastify middleware, attach a child logger per request:
 const reqLogger = logger.child({ request_id: req.id, user_id: req.user?.id });
 
 // Log with structured fields, not interpolated strings:
-reqLogger.info({ order_id: orderId, amount }, "order placed");
-reqLogger.error({ err, order_id: orderId }, "payment failed");
+reqLogger.info({ order_id: orderId, amount }, 'order placed');
+reqLogger.error({ err, order_id: orderId }, 'payment failed');
 ```
 
 **React Native / Expo (mobile):** pino is not available in the RN runtime. Avoid `console.*`

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,6 +1,8 @@
 ---
 description: TypeScript and TSX development standards for the Petry Projects organization
-applyTo: "**/*.ts,**/*.tsx"
+applyTo:
+  - "**/*.ts"
+  - "**/*.tsx"
 ---
 
 # TypeScript Development Standards
@@ -30,14 +32,17 @@ reason. Fix the underlying type issue instead.
 
 - **Formatter:** Prettier with `singleQuote: true`, `semi: true`, `trailingComma: "all"`,
   `printWidth: 100`, `tabWidth: 2`. Run `prettier --write` before committing.
-- **Linter:** ESLint flat config (`eslint.config.mjs`). Zero warnings, zero errors.
+- **Linter:** ESLint flat config (`eslint.config.js`). Zero warnings, zero errors.
 - **Imports:** Use `import type { ... }` for type-only imports. Organize imports: external
   packages first, then internal modules. No circular imports.
-- **No barrel files.** Avoid `index.ts` re-export files unless the project explicitly requires
-  them — they increase circular dependency risk and slow down bundlers.
+- **Barrel files:** Avoid `index.ts` re-export files in most cases — they increase circular
+  dependency risk and slow down bundlers. Exception: package entry points such as
+  `packages/ui/src/index.ts` that define a package's public API are required and must be
+  maintained.
 - **Naming:** `PascalCase` for types, interfaces, classes, and React components. `camelCase` for
   variables, functions, and methods. `SCREAMING_SNAKE_CASE` for module-level constants.
-  File names match the primary export (`UserRepository.ts`, `OrderSummary.tsx`).
+  File names match the primary export (`UserRepository.ts`). React Native components use the
+  directory-based pattern: `ComponentName/index.tsx` with a co-located `ComponentName.test.tsx`.
 
 ## Type Safety
 
@@ -84,9 +89,9 @@ mutate state.
 
 ## Structured Logging
 
-Use **pino** as the default structured logger. Never use `console.log`, `console.error`, or
-`console.warn` in application code (`console.*` is acceptable only in CLI tools and build
-scripts):
+**Node.js / server-side code:** Use **pino** as the default structured logger (add it as an
+explicit dependency). Never use `console.log`, `console.error`, or `console.warn` in
+application or library code (`console.*` is acceptable only in CLI tools and build scripts):
 
 ```typescript
 import pino from "pino";
@@ -100,6 +105,9 @@ reqLogger.info({ order_id: orderId, amount }, "order placed");
 reqLogger.error({ err, order_id: orderId }, "payment failed");
 ```
 
+**React Native / Expo (mobile):** pino is not available in the RN runtime. Avoid `console.*`
+in production paths; use a lightweight RN-compatible logger or route through the backend.
+
 Never log variables whose names end in `password`, `secret`, `token`, `api_key`, `cookie`, or
 `authorization`.
 
@@ -107,8 +115,9 @@ Never log variables whose names end in `password`, `secret`, `token`, `api_key`,
 
 - Use functional components with hooks exclusively. No class components.
 - Extract business logic into custom hooks or service functions — keep components presentational.
-- Use stable `data-testid` attributes for E2E test selectors; never match on CSS classes, DOM
-  hierarchy, or display text.
+- Use stable `testID` attributes for E2E/RTL selectors in React Native (the `data-testid`
+  attribute is web-only and is not supported by React Native's test renderer); never match on
+  CSS classes, DOM hierarchy, or display text.
 - Props interfaces use `PascalCase`: `interface ButtonProps { ... }`. Co-locate with the
   component file.
 - Do not import React explicitly (JSX transform handles it). Use `React.FC` only if required by

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,0 +1,140 @@
+---
+description: TypeScript and TSX development standards for the Petry Projects organization
+applyTo: "**/*.ts,**/*.tsx"
+---
+
+# TypeScript Development Standards
+
+These rules extend the org-level `copilot-instructions.md`. TypeScript is the primary language
+across all Petry Projects repositories.
+
+## Compiler Configuration
+
+Always use TypeScript in strict mode. All repositories MUST include these flags (or stricter):
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true
+  }
+}
+```
+
+Never use `// @ts-ignore` or `// @ts-expect-error` to silence type errors without a documented
+reason. Fix the underlying type issue instead.
+
+## Code Style
+
+- **Formatter:** Prettier with `singleQuote: true`, `semi: true`, `trailingComma: "all"`,
+  `printWidth: 100`, `tabWidth: 2`. Run `prettier --write` before committing.
+- **Linter:** ESLint flat config (`eslint.config.mjs`). Zero warnings, zero errors.
+- **Imports:** Use `import type { ... }` for type-only imports. Organize imports: external
+  packages first, then internal modules. No circular imports.
+- **No barrel files.** Avoid `index.ts` re-export files unless the project explicitly requires
+  them — they increase circular dependency risk and slow down bundlers.
+- **Naming:** `PascalCase` for types, interfaces, classes, and React components. `camelCase` for
+  variables, functions, and methods. `SCREAMING_SNAKE_CASE` for module-level constants.
+  File names match the primary export (`UserRepository.ts`, `OrderSummary.tsx`).
+
+## Type Safety
+
+- Prefer `unknown` over `any`. When `any` is unavoidable, add a comment explaining why.
+- Use branded types / nominal typing for domain identifiers and value objects:
+
+  ```typescript
+  type UserId = string & { readonly __brand: "UserId" };
+  type OrderId = string & { readonly __brand: "OrderId" };
+  ```
+
+- Use discriminated unions instead of optional fields where possible.
+- Avoid type assertions (`as SomeType`) at system boundaries — validate with a type guard or
+  schema parser (e.g., Zod) instead.
+- Use `readonly` for arrays and object properties that should not be mutated.
+
+## Domain-Driven Design Patterns
+
+- **Ubiquitous language:** Use domain terminology from the bounded context in type names,
+  variable names, and method names. Never rename domain concepts to generic terms.
+- **Bounded contexts:** Each context lives in its own directory (e.g., `src/orders/`,
+  `src/billing/`). Cross-context dependencies use well-defined interfaces or domain events —
+  never direct internal imports across context boundaries.
+- **Aggregate roots:** External code accesses child entities only through the aggregate root.
+  Return domain objects from repositories, not raw database rows.
+- **Value objects:** Model domain quantities, identifiers, and domain-specific strings as value
+  objects. Validate on construction; throw on invalid input.
+- **Repository pattern:** Persistence is abstracted behind repository interfaces the domain
+  defines. Infrastructure implements them. Domain code never imports database drivers, ORMs, or
+  storage libraries.
+
+## CQRS Naming Conventions
+
+| Concept | Convention | Examples |
+|---------|-----------|----------|
+| Command | Imperative verb + noun | `PlaceOrder`, `CancelSubscription` |
+| Event | Past-tense verb + noun | `OrderPlaced`, `SubscriptionCancelled` |
+| Query | `Get` / `List` / `Search` + noun | `GetOrderById`, `ListActiveUsers` |
+| Command handler | `Handle(cmd)` or `<Name>Handler` | `PlaceOrderHandler` |
+| Projection | Noun describing the view | `OrderSummaryProjection` |
+
+Commands MUST NOT return domain data — return the new entity ID or void. Queries MUST NOT
+mutate state.
+
+## Structured Logging
+
+Use **pino** as the default structured logger. Never use `console.log`, `console.error`, or
+`console.warn` in application code (`console.*` is acceptable only in CLI tools and build
+scripts):
+
+```typescript
+import pino from "pino";
+const logger = pino();
+
+// In Express/Fastify middleware, attach a child logger per request:
+const reqLogger = logger.child({ request_id: req.id, user_id: req.user?.id });
+
+// Log with structured fields, not interpolated strings:
+reqLogger.info({ order_id: orderId, amount }, "order placed");
+reqLogger.error({ err, order_id: orderId }, "payment failed");
+```
+
+Never log variables whose names end in `password`, `secret`, `token`, `api_key`, `cookie`, or
+`authorization`.
+
+## React Guidelines
+
+- Use functional components with hooks exclusively. No class components.
+- Extract business logic into custom hooks or service functions — keep components presentational.
+- Use stable `data-testid` attributes for E2E test selectors; never match on CSS classes, DOM
+  hierarchy, or display text.
+- Props interfaces use `PascalCase`: `interface ButtonProps { ... }`. Co-locate with the
+  component file.
+- Do not import React explicitly (JSX transform handles it). Use `React.FC` only if required by
+  the project — prefer plain function declarations.
+
+## Error Handling
+
+- Use typed `Result` patterns or typed error unions rather than throwing for recoverable errors
+  at domain boundaries.
+- Always handle the error case explicitly — never use `.catch(() => {})` silently.
+- Fail fast with a clear, descriptive error when an invariant is violated.
+
+## Testing (Vitest / Jest)
+
+- Name tests as functional requirement specifications:
+  `it("submitting a valid order creates a confirmed record with correct totals")`.
+- Use `describe` blocks to group by feature or class under test.
+- Mock only external I/O (databases, HTTP, file system). Never mock domain logic.
+- Co-locate unit tests next to source files (`UserRepository.test.ts` beside
+  `UserRepository.ts`).
+- Mutation testing (Stryker) runs in CI for repos that configure it — write meaningful
+  assertions, not trivial coverage padding.
+
+## Electron-Specific (TalkTerm and desktop repos)
+
+- Keep main-process and renderer-process code strictly separated. Never import renderer modules
+  in the main process or vice versa.
+- Use `contextBridge` for all IPC; never expose `ipcRenderer` directly to renderer code.
+- Validate all data crossing the IPC bridge as if it were external user input.

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,8 +1,6 @@
 ---
 description: TypeScript and TSX development standards for the Petry Projects organization
-applyTo:
-  - "**/*.ts"
-  - "**/*.tsx"
+applyTo: "**/*.ts,**/*.tsx"
 ---
 
 # TypeScript Development Standards
@@ -12,12 +10,21 @@ across all Petry Projects repositories.
 
 ## Compiler Configuration
 
-Always use TypeScript in strict mode. All repositories MUST include these flags (or stricter):
+Always use TypeScript in strict mode. All repositories MUST include at minimum:
 
 ```json
 {
   "compilerOptions": {
-    "strict": true,
+    "strict": true
+  }
+}
+```
+
+The following flags are strongly recommended and should be added when introducing new projects or when the codebase is ready to adopt them (the current broodly repo enables only `strict`):
+
+```json
+{
+  "compilerOptions": {
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "noImplicitOverride": true
@@ -120,8 +127,10 @@ Never log variables whose names end in `password`, `secret`, `token`, `api_key`,
   CSS classes, DOM hierarchy, or display text.
 - Props interfaces use `PascalCase`: `interface ButtonProps { ... }`. Co-locate with the
   component file.
-- Do not import React explicitly (JSX transform handles it). Use `React.FC` only if required by
-  the project — prefer plain function declarations.
+- Do not import React solely for JSX — the JSX transform handles it automatically. Do import
+  React when you need React APIs or namespace types (e.g., `React.ComponentProps`,
+  `React.forwardRef`, `React.ReactNode`). Use `React.FC` only if required by the project —
+  prefer plain function declarations.
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary

- Adds `.github/copilot-instructions.md` customized for broodly's pnpm monorepo stack
- Copies `typescript.instructions.md`, `javascript.instructions.md`, and `go.instructions.md` from the org canonical source
- Covers: monorepo layout (apps/mobile + apps/api), pnpm workspace conventions, Expo SDK 55 with jest-expo, Go 1.24 chi router, Gluestack UI v3 + NativeWind v4

## Stack discovered

pnpm monorepo · Node.js ≥ 20 · Go 1.24 · Expo SDK 55 · React Native 0.83 · React 19 · TypeScript ~5.9.3 · Gluestack UI v3 · NativeWind v4 · Jest (jest-expo) · ESLint ^10 · Prettier ^3 · golangci-lint · go-chi/chi v5

## References

- Org-wide rollout: petry-projects/.github PR #328
- Org baseline: [petry-projects/.github copilot-instructions.md](https://github.com/petry-projects/.github/blob/main/.github/copilot-instructions.md)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository-scoped Copilot guidance describing project scope, tech stack, repo layout, local dev commands, environment requirements, and testing notes.
  * Added organization-wide Go, JavaScript, and TypeScript/TSX development standards covering formatting, linting, typing, logging, error handling, concurrency, testing, and tooling.
  * Updated ignore rules to exclude a local development directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->