### PR TITLE
rollout: deploy pr-review-mention standard workflow

### DIFF
--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -1,25 +1,3 @@
-# ─────────────────────────────────────────────────────────────────────────────
-# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/pr-review-mention.yml
-# Standard:        petry-projects/.github/standards/ci-standards.md
-# Reusable:        petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml
-#
-# AGENTS — READ BEFORE EDITING:
-#   • This file is a THIN CALLER STUB. All review-dispatch logic lives in the
-#     reusable workflow above.
-#   • You MAY change: the tag in the `uses:` line when upgrading the reusable
-#     workflow version (e.g. bump `@v1` → `@v2` when petry-projects/.github cuts a new release).
-#   • You MUST NOT change: trigger events or the job-level `permissions:` block —
-#     reusable workflows can be granted no more permissions than the calling job,
-#     so removing the stanza breaks the reusable's gh API calls.
-#   • If you need different behaviour, open a PR against the reusable in the
-#     central repo.
-#   • When publishing a new version of this reusable, also update this template and
-#     open a fanout PR across all caller repos.
-# ─────────────────────────────────────────────────────────────────────────────
-#
-# PR Review Mention — thin caller for the org-level reusable.
-# To adopt: copy this file to .github/workflows/pr-review-mention.yml in your repo.
-# Requires: GH_PAT_WORKFLOWS org secret (already present in petry-projects org).
 name: PR Review — Mention Trigger
 
 on:
@@ -36,5 +14,6 @@ jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310 # v2
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v2
     secrets: inherit
+

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ yarn-error.log*
 .dev-lead/
 .dev-lead/
 .dev-lead/
+.dev-lead/


### PR DESCRIPTION
Deploy standard pr-review-mention.yml workflow from petry-projects/.github standards. This enables PR review mentions to trigger the org-level review agent.